### PR TITLE
Ensure get_all function doesnt add the same API result more than once

### DIFF
--- a/seshat_api/base_model.py
+++ b/seshat_api/base_model.py
@@ -298,7 +298,9 @@ class BaseAPICall:
             results = response.get('results', [])
             if not results:
                 break
-            all_results.extend(results)
+            for result in results:
+                if result['id'] not in [r['id'] for r in all_results]:
+                    all_results.append(result)
             page += 1
 
         return all_results


### PR DESCRIPTION
Closes #20 

The function now ensures that an API result with the same ID hasn't already been added. The cause of the bug may have been if the pagination sometimes had the same result on multiple pages, so adding the results from all pages to one list meant there were duplicates.